### PR TITLE
make InfoPanel update on each time noteLink variable changes

### DIFF
--- a/browser/main/Detail/InfoPanel.js
+++ b/browser/main/Detail/InfoPanel.js
@@ -75,7 +75,7 @@ class InfoPanel extends React.Component {
           <p styleName='infoPanel-sub'>{i18n.__('CREATION DATE')}</p>
         </div>
 
-        <div>
+        <div key={noteLink}>
           <input
             styleName='infoPanel-noteLink'
             ref='noteLink'


### PR DESCRIPTION
## Description

The InfoPanel component doesn't rerender when noteLink props changes.
This caused issue3593.
I fixed this to rerender when noteLink variable changes. 

## Issue fixed

issue #3593 

## Type of changes

- :black_circle: Bug fix (Change that fixed an issue)

## Checklist:

- :black_circle: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :black_circle: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
- :black_circle: This PR will modify the UI or affects the UX
- :white_circle: This PR will add/update/delete a keybinding
