### PR TITLE
Change app reload shortcut to ctrl + shift + r

### DIFF
--- a/lib/main-menu.js
+++ b/lib/main-menu.js
@@ -258,7 +258,7 @@ const view = {
   submenu: [
     {
       label: 'Reload',
-      accelerator: 'CommandOrControl+R',
+      accelerator: 'CommandOrControl+Shift+R',
       click() {
         BrowserWindow.getFocusedWindow().reload()
       }


### PR DESCRIPTION
## Description

Fixes #2825 by changing app reload shortcut from `ctrl` + `r` to `ctr` + `shift` + `r`

## Issue fixed
#2825

<!--
Please make sure you fill in these checkboxes,
your PR will be reviewed faster if we know exactly what it does.

Change :white_circle: to :radio_button: in all the options that apply
-->

## Type of changes

- :radio_button: Bug fix (Change that fixed an issue)
- :white_circle: Breaking change (Change that can cause existing functionality to change)
- :white_circle: Improvement (Change that improves the code. Maybe performance or development improvement)
- :white_circle: Feature (Change that adds new functionality)
- :white_circle: Documentation change (Change that modifies documentation. Maybe typo fixes)

## Checklist:

- :radio_button: My code follows [the project code style](docs/code_style.md)
- :white_circle: I have written test for my code and it has been tested
- :radio_button: All existing tests have been passed
- :white_circle: I have attached a screenshot/video to visualize my change if possible
- :radio_button: This PR will modify the UI or affects the UX
- :radio_button: This PR will add/update/delete a keybinding


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#2825: Ctrl-R reloads Boostnote on vim mode](https://issuehunt.io/repos/53266139/issues/2825)
---
</details>
<!-- /Issuehunt content-->